### PR TITLE
Update SPARQLController.php

### DIFF
--- a/app/controllers/tdt/core/datacontrollers/SPARQLController.php
+++ b/app/controllers/tdt/core/datacontrollers/SPARQLController.php
@@ -317,9 +317,9 @@ class SPARQLController extends ADataController {
 
         // Note that the logging of invalid parameters will happen twice, as we construct and execute
         // the count query as well as the given query
-        foreach($parameters as $key => $value){
-            \Log::warning("The parameters $key with value $value was given as a SPARQL query parameter, but no placeholder in the SPARQL query named $key was found.");
-        }
+        //foreach($parameters as $key => $value){
+        //    \Log::warning("The parameters $key with value $value was given as a SPARQL query parameter, but no placeholder in the SPARQL query named $key was found.");
+        //}
 
         return $query;
     }


### PR DESCRIPTION
Logging will throw an excpetion when used with multivalue-request params.
This obviouosly needs a better solution, but avoiding breakage at the expence of some missed lgging seems a decent quick-hack compromise.
