### PR TITLE
Fix URI resolving when dataset URI contains a dot

### DIFF
--- a/app/Tdt/Core/Datasets/DatasetController.php
+++ b/app/Tdt/Core/Datasets/DatasetController.php
@@ -207,7 +207,7 @@ class DatasetController extends ApiController
         if (!class_exists($formatter_class)) {
 
             // Re-attach the dot with the latter part of the uri
-	    $uri .= '.' . strtolower($possible_extension);
+            $uri .= '.' . strtolower($possible_extension);
 
             return array($uri, null);
         }

--- a/app/Tdt/Core/Datasets/DatasetController.php
+++ b/app/Tdt/Core/Datasets/DatasetController.php
@@ -207,12 +207,12 @@ class DatasetController extends ApiController
         if (!class_exists($formatter_class)) {
 
             // Re-attach the dot with the latter part of the uri
-            $uri .= '.' . $possible_extension;
+	    $uri .= '.' . strtolower($possible_extension);
 
             return array($uri, null);
         }
 
-        return array($uri, $possible_extension);
+        return array($uri, strtolower($possible_extension));
     }
 
     /**


### PR DESCRIPTION
When a dataset URI contains a dot in the collection or resource name, a 404 is returned when retrieving the dataset. Parts of the URI are transformed to uppercase during URI processing, but they aren't reverted to lowercase afterwards causing a 404.