### PR TITLE
Use longtext for DB caching.

### DIFF
--- a/app/database/migrations/2015_12_07_165310_use_longtext_cache.php
+++ b/app/database/migrations/2015_12_07_165310_use_longtext_cache.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UseLongtextCache extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		// Drop to get rid of any cache data as well.
+		Schema::drop('cache');
+		Schema::create('cache', function ($table) {
+			$table->string('key')->unique();
+			$table->longText('value');
+			$table->integer('expiration');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		// Drop to get rid of any cache data as well.
+		Schema::drop('cache');
+		Schema::create('cache', function ($table) {
+			$table->string('key')->unique();
+			$table->text('value');
+			$table->integer('expiration');
+		});
+	}
+
+}


### PR DESCRIPTION
Prevent DecryptException for long cache values. See https://laracasts.com/discuss/channels/general-discussion/daeling-with-decryptexceptioninvalid-data