### PR TITLE
Fix determination of rest_params if collection_uri contains '/'

### DIFF
--- a/app/Tdt/Core/Datasets/DatasetController.php
+++ b/app/Tdt/Core/Datasets/DatasetController.php
@@ -76,7 +76,9 @@ class DatasetController extends ApiController
                     // Get REST parameters
 
                     $uri_segments = explode('/', $uri);
-                    $rest_parameters = array_diff($uri_segments, array($definition['collection_uri'], $definition['resource_name']));
+                    $definition_segments = explode('/', $definition['collection_uri']);
+		    array_push($definition_segments, $definition['resource_name']);
+                    $rest_parameters = array_diff($uri_segments, $definition_segments);		    
                     $rest_parameters = array_values($rest_parameters);
 
                     $throttle_response = $this->applyThrottle($definition);


### PR DESCRIPTION
REST parameters are not correctly retrieved from the URI if the dataset `collection_uri` contains `/`.

I tried to apply this change in the development branch, but the DatasetController in the development branch seems to have diverged from the one in master due to #341.  