### PR TITLE
Change dcat:contactPoint validation from url to email.

### DIFF
--- a/app/Tdt/Core/Repositories/DefinitionRepository.php
+++ b/app/Tdt/Core/Repositories/DefinitionRepository.php
@@ -11,7 +11,7 @@ class DefinitionRepository extends BaseDefinitionRepository implements Definitio
     protected $dcat_rules = [
         'resource_name' => 'required',
         'collection_uri' => 'required|collectionuri',
-        'contact_point' => 'uri',
+        'contact_point' => 'required|email',
     ];
 
     protected $geodcat_rules = [


### PR DESCRIPTION
The field dcat:contactPoint should be a required email address according to the flemish open data guidelines. 

Source: Page 73 --> https://overheid.vlaanderen.be/sites/default/files/Open_data_handboek_2016.pdf