### PR TITLE
Added --force flag to some artisan commands.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,10 @@
         "post-install-cmd": [
             "php artisan optimize",
             "php artisan migrate:install",
-            "php artisan migrate",
-            "php artisan migrate --package=cartalyst/sentry",
-            "php artisan db:seed",
-            "php artisan migrate --package=tdt/input",
+            "php artisan migrate --force",
+            "php artisan migrate --package=cartalyst/sentry --force",
+            "php artisan db:seed --force",
+            "php artisan migrate --package=tdt/input --force",
             "php artisan asset:publish tdt/input",
             "php artisan config:publish tdt/input"
         ],
@@ -53,8 +53,8 @@
         ],
         "post-update-cmd": [
             "php artisan optimize",
-            "php artisan migrate",
-            "php artisan migrate --package=cartalyst/sentry"
+            "php artisan migrate --force",
+            "php artisan migrate --package=cartalyst/sentry --force"
         ],
         "post-create-project-cmd": [
             "php artisan key:generate"


### PR DESCRIPTION
This enables an automatic 'composer install' command in what Laravel considers "production environments". Normally it asks confirmation (you have to type "y" at some steps), but this is not desired when running in an automated environment e.g. during building a Docker container.